### PR TITLE
Add bgfx-single-threaded feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ cc = { version = "1.0", features = ["parallel"] }
 
 [features]
 bgfx-debug = []
+bgfx-single-threaded = []

--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,17 @@ fn main() {
 
     // Don't include decode of ASTC to reduce code size and is unlikely a common use-case.
     build.define("BIMG_DECODE_ASTC", "0");
-    build.define("BGFX_CONFIG_MULTITHREADED", "0");
+
+    // Optionally disable multi-threading
+    #[cfg(feature = "bgfx-single-threaded")]
+    {
+        build.define("BGFX_CONFIG_MULTITHREADED", "0");
+    }
+
+    #[cfg(not(feature = "bgfx-single-threaded"))]
+    {
+        build.define("BGFX_CONFIG_MULTITHREADED", "1");
+    }
 
     if env.contains("windows") {
         build.define("BGFX_CONFIG_RENDERER_VULKAN", "1");


### PR DESCRIPTION
The default for BGFX is to be multi-threaded
(see https://bkaradzic.github.io/bgfx/internals.html). This changes the default to be multi-threaded and adds a feature for disabling multi-threading.